### PR TITLE
Fix operator-precedence bug in stream varint decoder

### DIFF
--- a/libp2p/utils/varint.py
+++ b/libp2p/utils/varint.py
@@ -78,7 +78,7 @@ async def decode_uvarint_from_stream(reader: Reader) -> int:
 
         res += (value & LOW_MASK) << shift
 
-        if not value & HIGH_MASK:
+        if not (value & HIGH_MASK):
             break
     return res
 


### PR DESCRIPTION
## What was wrong?
Bug: [decode_uvarint_from_stream]mis-detected the varint continuation bit because of operator-precedence: `if not value & HIGH_MASK` was evaluated as `(not value) & HIGH_MASK`, causing the loop to fail to break on the final byte and producing incorrect decodes or hangs.

## How was it fixed?
Changed the check to `if not (value & HIGH_MASK)` so the bitwise AND is evaluated before the logical `not`. This correctly detects the high/continuation bit and breaks at the final varint byte.

### To-Do
- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture


<img width="270" height="148" alt="image" src="https://github.com/user-attachments/assets/2fa41131-360b-493f-82de-fe8fad379524" />
